### PR TITLE
Round using 2 decimal places past the precision point.

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -75,8 +75,8 @@ function parse(value, opts, useRounding = true) {
     v = 0;
   }
 
-  // Handle additional decimal for proper rounding
-  v = v.toFixed(1);
+  // Handle additional decimal for proper rounding.
+  v = v.toFixed(2);
 
   return useRounding ? round(v) : v;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -243,7 +243,7 @@ test('should use source formatting for mixed currency formats', t => {
 });
 
 test('should default rounding when parsing', t => {
-  var round1 = currency(1.234)
+  var round1 = currency(1.2349)
     , round2 = currency(5.6789)
     , multiply = currency(10.00)
     , divide = currency(0.01);


### PR DESCRIPTION
This would resolve the issue in https://github.com/scurker/currency.js/issues/133

All tests pass, but I understand this is potentially a big change, so I thought this could at least be a place to add additional tests to ensure it works within your expectations.