### PR TITLE
Update currency.js.flow for flow@0.82.0

### DIFF
--- a/src/currency.js.flow
+++ b/src/currency.js.flow
@@ -1,6 +1,6 @@
 // @flow
 
-declare type $currency$any = number | string | currency;
+declare type $currency$any = number | string | typeof currency;
 
 declare type $currency$opts = {
   symbol?: string,
@@ -16,12 +16,12 @@ declare type $currency$opts = {
 }
 
 declare interface $currency {
-  (value: $currency$any, opts?: $currency$opts): currency,
-  add(number: $currency$any): currency;
-  subtract(number: $currency$any): currency;
-  multiply(number: $currency$any): currency;
-  divide(number: $currency$any): currency;
-  distribute(count: number): Array<currency>;
+  (value: $currency$any, opts?: $currency$opts): typeof currency,
+  add(number: $currency$any): typeof currency;
+  subtract(number: $currency$any): typeof currency;
+  multiply(number: $currency$any): typeof currency;
+  divide(number: $currency$any): typeof currency;
+  distribute(count: number): Array<typeof currency>;
   dollars(): number;
   cents(): number;
   format(useSymbol?: boolean): string;


### PR DESCRIPTION
Fixes flow@0.82.0 error 

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/currency.js/dist/currency.js.flow:3:48

Cannot use function type as a type because function type is a value. To get the type of a value use typeof.

     1│ // @flow
     2│
     3│ declare type $currency$any = number | string | currency;
     4│
     5│ declare type $currency$opts = {
     6│   symbol?: string,
```