### PR TITLE
add ability to format with a function or options object; deprecate old patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,6 +1493,42 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+      "integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1721,6 +1757,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-map": {
@@ -3303,6 +3345,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dir-glob": {
@@ -5906,6 +5954,12 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -6059,6 +6113,12 @@
           }
         }
       }
+    },
+    "lolex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
+      "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -7464,6 +7524,19 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nise": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
+      "integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -8286,6 +8359,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -9119,6 +9209,32 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.2.tgz",
+      "integrity": "sha512-thErC1z64BeyGiPvF8aoSg0LEnptSaWE7YhdWWbWXgelOyThent7uKOnnEh9zBxDbKixtr5dEko+ws1sZMuFMA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.1",
+        "diff": "^3.5.0",
+        "lolex": "^4.0.1",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -9844,6 +9960,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "minify:docs": "html-minifier --input-dir ./docs/build --output-dir ./docs/build --file-ext html --collapse-whitespace --decode-entities --minify-css --minify-js",
     "prepare": "npm run build",
     "pretest:js": "npm run transpile:es",
+    "pretest:typescript": "npm run copy-typescript-definition",
+    "pretest:flow": "npm run copy-flow-definition",
     "transpile:es": "rollup -c ./config/rollup.config.js",
     "transpile:umd": "rollup -c ./config/rollup.umd.js",
     "transpile": "npm-run-all transpile:*",
@@ -86,6 +88,7 @@
     "pretty-bytes": "^5.3.0",
     "rollup": "^1.17.0",
     "rollup-plugin-babel": "^4.3.3",
+    "sinon": "^7.3.2",
     "typescript": "^3.5.3"
   },
   "nyc": {

--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -1,5 +1,6 @@
 declare namespace currency {
   type Any = number | string | currency;
+  type Format = (currency?: currency, opts?: Options) => string;
   interface Constructor {
     (value: currency.Any, opts?: currency.Options): currency,
     new (value: currency.Any, opts?: currency.Options): currency
@@ -8,13 +9,13 @@ declare namespace currency {
     symbol?: string,
     separator?: string,
     decimal?: string,
-    formatWithSymbol?: boolean,
     errorOnInvalid?: boolean,
     precision?: number,
     increment?: number,
     useVedic?: boolean,
     pattern?: string,
     negativePattern?: string,
+    format?: currency.Format
   }
 }
 
@@ -26,7 +27,7 @@ declare interface currency {
   distribute(count: number): Array<currency>;
   dollars(): number;
   cents(): number;
-  format(useSymbol?: boolean): string;
+  format(opts?: currency.Options | currency.Format): string;
   toString(): string;
   toJSON(): number;
   readonly intValue: number;

--- a/src/currency.js.flow
+++ b/src/currency.js.flow
@@ -1,17 +1,19 @@
 // @flow
 declare type $currency$any = number | string | currency;
 
+declare type formatFunction = (currency: currency, options: $currency$opts) => string;
+
 declare type $currency$opts = {
   symbol?: string,
   separator?: string,
   decimal?: string,
-  formatWithSymbol?: boolean,
   errorOnInvalid?: boolean,
   precision?: number,
   increment?: number,
   useVedic?: boolean,
   pattern?: string,
-  negativePattern?: string
+  negativePattern?: string,
+  format?: formatFunction
 }
 
 declare class currency {
@@ -24,7 +26,7 @@ declare class currency {
   distribute(count: number): Array<currency>;
   dollars(): number;
   cents(): number;
-  format(useSymbol?: boolean): string;
+  format(options?: $currency$opts | formatFunction): string;
   toString(): string;
   toJSON(): number;
   +intValue: number;

--- a/test/test.flow.js
+++ b/test/test.flow.js
@@ -17,13 +17,13 @@ currency(1.23, {
   symbol: '$',
   separator: ',',
   decimal: '.',
-  formatWithSymbol: true,
   errorOnInvalid: true,
   precision: 2,
   increment: .05,
   useVedic: false,
   pattern: '!#',
-  negativePattern: '-!#'
+  negativePattern: '-!#',
+  format: (currency, options) => '1.23'
 });
 
 // add
@@ -57,7 +57,8 @@ let c1: number = currencyInstance.cents();
 
 // format
 let s1: string = currencyInstance.format();
-let s2: string = currencyInstance.format(true);
+let s2: string = currencyInstance.format({ symbol: '£' });
+let s3: string = currencyInstance.format((currency, options) => '1.23');
 
 // property values
 let v1: number = currencyInstance.value;

--- a/test/test.ts
+++ b/test/test.ts
@@ -20,13 +20,13 @@ currency(1.23, {
   symbol: '$',
   separator: ',',
   decimal: '.',
-  formatWithSymbol: true,
   errorOnInvalid: true,
   precision: 2,
   increment: .05,
   useVedic: false,
   pattern: '!#',
-  negativePattern: '-!#'
+  negativePattern: '-!#',
+  format: (currency: currency, options: currency.Options) => '1.23'
 });
 
 // add
@@ -60,7 +60,8 @@ let c1: number = currencyInstance.cents();
 
 // format
 let s1: string = currencyInstance.format();
-let s2: string = currencyInstance.format(true);
+let s2: string = currencyInstance.format({ symbol: '£' });
+let s3: string = currencyInstance.format((currency: currency, options: currency.Options) => '1.23');
 
 // property values
 let v1: number = currencyInstance.value;


### PR DESCRIPTION
Formatting has always been limited to the predefined set options, with no option to change the formatting _after_ a currency object has been instantiated. With this change, a function can be used with the initial options or when calling `currency.format()`.

_Removed:_

* options: `formatWithSymbol`
* `currency.function(useSymbol)`

_Added:_

* options: `format`
* `currency.format(options | function)`

Related: #191 