### PR TITLE
Parse currency as cents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,15 @@ var value = currency("123.45");
 currency(value);    // 123.45
 ```
 
+Currency accepts decimal values (i.e. `1.23`) with a default precision of 2, but can accept a minor currency unit (e.g. cents in a dollar). This will respect the precision option when parsing.
+
+```javascript
+currency(123, { fromCents: true });               // 1.23
+currency('123', { fromCents: true });             // 1.23
+currency(123, { fromCents: true, precision: 0 }); // 123
+currency(123, { fromCents: true, precision: 3 }); // 0.123
+```
+
 There's various arithmetic methods that help take the guesswork out of trying to resolve floating point problems.
 
 ```javascript
@@ -129,6 +138,9 @@ When implementing a currency that implements rounding, setting the increment val
 
 `useVedic` *default*: `false`<br/>
 Formats number groupings using the Indian Numbering System, i.e. `10,00,000.00`
+
+`fromCents` *default*: `false`<br/>
+Parse the amount value as a minor currency unit (e.g. cents in a dollar) instead of dollars.
 
 > View more examples and full documentation at [scurker.github.io/currency.js](http://scurker.github.io/currency.js).
 

--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -15,7 +15,8 @@ declare namespace currency {
     useVedic?: boolean,
     pattern?: string,
     negativePattern?: string,
-    format?: currency.Format
+    format?: currency.Format,
+    fromCents?: boolean
   }
 }
 

--- a/src/currency.js
+++ b/src/currency.js
@@ -6,7 +6,8 @@ const defaults = {
   precision: 2,
   pattern: '!#',
   negativePattern: '-!#',
-  format
+  format,
+  fromCents: false
 };
 
 const round = v => Math.round(v);
@@ -53,20 +54,19 @@ function currency(value, opts) {
 
 function parse(value, opts, useRounding = true) {
   let v = 0
-    , { decimal, errorOnInvalid, precision: decimals } = opts
+    , { decimal, errorOnInvalid, precision: decimals, fromCents } = opts
     , precision = pow(decimals)
     , isNumber = typeof value === 'number';
 
   if (isNumber || value instanceof currency) {
-    v = ((isNumber ? value : value.value) * precision);
+    v = (isNumber ? value : value.value);
   } else if (typeof value === 'string') {
     let regex = new RegExp('[^-\\d' + decimal + ']', 'g')
       , decimalString = new RegExp('\\' + decimal, 'g');
     v = value
-          .replace(/\((.*)\)/, '-$1')   // allow negative e.g. (1.99)
-          .replace(regex, '')           // replace any non numeric values
-          .replace(decimalString, '.')  // convert any decimal values
-          * precision;                  // scale number to integer value
+          .replace(/\((.*)\)/, '-$1')    // allow negative e.g. (1.99)
+          .replace(regex, '')            // replace any non numeric values
+          .replace(decimalString, '.');  // convert any decimal values
     v = v || 0;
   } else {
     if(errorOnInvalid) {
@@ -75,10 +75,15 @@ function parse(value, opts, useRounding = true) {
     v = 0;
   }
 
-  // Handle additional decimal for proper rounding.
-  v = v.toFixed(4);
+  if (fromCents) {
+    v = Math.trunc(v);               // Remove decimals. Invalid for cents.
+  } else {
+    v *= precision;                  // scale number to integer value
+    v = v.toFixed(4);                // Handle additional decimal for proper rounding.
+    v = useRounding ? round(v) : v;
+  }
 
-  return useRounding ? round(v) : v;
+  return v;
 }
 
 /**

--- a/src/currency.js.flow
+++ b/src/currency.js.flow
@@ -13,7 +13,8 @@ declare type $currency$opts = {
   useVedic?: boolean,
   pattern?: string,
   negativePattern?: string,
-  format?: formatFunction
+  format?: formatFunction,
+  fromCents?: boolean
 }
 
 declare class currency {

--- a/test/test.js
+++ b/test/test.js
@@ -480,3 +480,71 @@ test('should throw exception with invalid input', t => {
   // eslint-disable-next-line no-undefined
   t.throws(function() { currency(undefined, { errorOnInvalid: true }); }, Error, 'Threw exception');
 });
+
+test('should allow creation from cents', t => {
+  let c1 = value => currency(value, { fromCents: true, precision: 2 });
+  let c2 = value => currency(value, { fromCents: true, precision: 0 });
+  let c3 = value => currency(value, { fromCents: true, precision: 3 });
+
+  t.is(c1(500).toString(), '5.00', 'value is not parsed from cents to 5.00');
+  t.is(c1(500.678).toString(), '5.00', 'value does not truncate decimals when parsed from cents');
+  t.is(c1('455').toString(), '4.55', 'value is not parsed from a string to cents');
+  t.is(c2(500).toString(), '500', 'value is not parsed from cents to 5.00');
+  t.is(c2(500.678).toString(), '500', 'value does not truncate decimals when parsed from cents');
+  t.is(c2('455').toString(), '455', 'value is not parsed from a string to cents');
+  t.is(c3(500).toString(), '0.500', 'value is not parsed from cents to 5.00');
+  t.is(c3(500.678).toString(), '0.500', 'value does not truncate decimals when parsed from cents');
+  t.is(c3('455').toString(), '0.455', 'value is not parsed from a string to cents');
+});
+
+test('should parse cents from a number when using fromCents option', t => {
+  let c1 = currency(123, { fromCents: true });
+  let c2 = currency(123, { fromCents: true, precision: 0 });
+  let c3 = currency(123, { fromCents: true, precision: 3 });
+
+  t.is(c1.value, 1.23);
+  t.is(c1.intValue, 123);
+  t.is(c2.value, 123);
+  t.is(c2.intValue, 123);
+  t.is(c3.value, 0.123);
+  t.is(c3.intValue, 123);
+});
+
+test('should truncate decimals from a number when using fromCents option', t => {
+  let c1 = currency(123.34, { fromCents: true });
+  let c2 = currency(123.12, { fromCents: true, precision: 0 });
+  let c3 = currency(123.987, { fromCents: true, precision: 3 });
+
+  t.is(c1.value, 1.23);
+  t.is(c1.intValue, 123);
+  t.is(c2.value, 123);
+  t.is(c2.intValue, 123);
+  t.is(c3.value, 0.123);
+  t.is(c3.intValue, 123);
+});
+
+test('should parse cents from a string when using fromCents option', t => {
+  let c1 = currency('123', { fromCents: true });
+  let c2 = currency('123', { fromCents: true, precision: 0 });
+  let c3 = currency('123', { fromCents: true, precision: 3 });
+
+  t.is(c1.value, 1.23);
+  t.is(c1.intValue, 123);
+  t.is(c2.value, 123);
+  t.is(c2.intValue, 123);
+  t.is(c3.value, 0.123);
+  t.is(c3.intValue, 123);
+});
+
+test('should truncate decimals from a string when using fromCents option', t => {
+  let c1 = currency('123.34', { fromCents: true });
+  let c2 = currency('123.12', { fromCents: true, precision: 0 });
+  let c3 = currency('123.987', { fromCents: true, precision: 3 });
+
+  t.is(c1.value, 1.23);
+  t.is(c1.intValue, 123);
+  t.is(c2.value, 123);
+  t.is(c2.intValue, 123);
+  t.is(c3.value, 0.123);
+  t.is(c3.intValue, 123);
+});


### PR DESCRIPTION
Closes #166. A couple of notes:

 * Fully backward-compatible. Supports all existing defaults.
* Respects the precision option
* Truncates decimals passed in when `fromCents` is true.
* Added docs, TypeScript, and Flow data

Let me know what you think.