### PR TITLE
Fix Usage docs typos

### DIFF
--- a/docs/01-usage.md
+++ b/docs/01-usage.md
@@ -38,9 +38,9 @@ currency(2.51).add(.01);      // => 2.52
 currency(2.52).subtract(.01); // 2.51
 ```
 
-Since *currency.js* handles values internally as integers, there is a limit to the precision that can be stored before encountering precision errors. This should be okay for most reasonable values of currencies. As long as your currencies are less than 2<sup>52</sup> (in cents) or `90,071,992,547,409.91`, you should not see any problems.
+Since *currency.js* handles values internally as integers, there is a limit to the precision that can be stored before encountering precision errors. This should be okay for most reasonable values of currencies. As long as your currencies are less than 2<sup>53</sup> (in cents) or `90,071,992,547,409.91`, you should not see any problems.
 
-*currency.js* also works with a variety of strings. This makes it easy to work into your UI without having do do string to number conversion or vice versa.
+*currency.js* also works with a variety of strings. This makes it easy to work into your UI without having to do string to number conversion or vice versa.
 
 ```js
 var c = currency("$1,234.56").add("890.12"); // 2124.68


### PR DESCRIPTION
max int size is 2^53, not 2^52, and there was a small typo as well in the same file. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER

This aligns with `readme.md`.