### PR TITLE
Remove traces of `formatWithSymbol`.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,7 @@ euro("1.237,72").subtract(300).format();          // "€937,72"
 *currency.js* comes with its own set of default options conforming to USD. You can customize these according to your locale.
 
 `symbol` *default*: `$`<br/>
-When `formatWithSymbol` is set to `true`, will include the currency symbol when calling `currency.format()`.
+Currency symbol included when calling `currency.format()`.
 
 `separator` *default*: `,`<br/>
 Separator dividing the number groups when calling `currency.format()`.

--- a/test/test.js
+++ b/test/test.js
@@ -314,7 +314,7 @@ test('should format vedic groupings', t => {
 });
 
 test('should format using patterns', t => {
-  let c = (value, opts) => currency(value, Object.assign({}, { formatWithSymbol: true, pattern: '# !'}, opts))
+  let c = (value, opts) => currency(value, Object.assign({}, { pattern: '# !'}, opts))
     , value1 = c(1.23)
     , value2 = c(1234.56)
     , value3 = c(1234567.89)
@@ -329,7 +329,7 @@ test('should format using patterns', t => {
 });
 
 test('should format using negative patterns', t => {
-  let c = (value, opts) => currency(value, Object.assign({}, { formatWithSymbol: true, negativePattern: '! (#)'}, opts))
+  let c = (value, opts) => currency(value, Object.assign({}, { negativePattern: '! (#)'}, opts))
     , value1 = c(-1.23)
     , value2 = c(-1234.56)
     , value3 = c(-1234567.89)


### PR DESCRIPTION
It looks like `formatWithSymbol` was removed in https://github.com/scurker/currency.js/commit/cad3e45b5e59882586db2611da29e1a86079095a, but traces of it still existed in the codebase.