### PR TITLE
TS declaration declares currency global

### DIFF
--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -1,42 +1,42 @@
-declare namespace currency {
-  type Any = number | string | currency;
-  type Format = (currency?: currency, opts?: Options) => string;
-  interface Constructor {
-    (value: currency.Any, opts?: currency.Options): currency,
-    new (value: currency.Any, opts?: currency.Options): currency
-  }
-  interface Options {
-    symbol?: string,
-    separator?: string,
-    decimal?: string,
-    errorOnInvalid?: boolean,
-    precision?: number,
-    increment?: number,
-    useVedic?: boolean,
-    pattern?: string,
-    negativePattern?: string,
-    format?: currency.Format,
-    fromCents?: boolean
-  }
-}
-
-declare interface currency {
-  add(number: currency.Any): currency;
-  subtract(number: currency.Any): currency;
-  multiply(number: currency.Any): currency;
-  divide(number: currency.Any): currency;
-  distribute(count: number): Array<currency>;
-  dollars(): number;
-  cents(): number;
-  format(opts?: currency.Options | currency.Format): string;
-  toString(): string;
-  toJSON(): number;
-  readonly intValue: number;
-  readonly value: number;
-}
-
-declare const currency : currency.Constructor;
-
 declare module 'currency.js' {
-  export = currency;
+    namespace currency {
+        type Any = number | string | currency;
+        type Format = (currency?: currency, opts?: Options) => string;
+        interface Constructor {
+            (value: currency.Any, opts?: currency.Options): currency,
+            new(value: currency.Any, opts?: currency.Options): currency
+        }
+        interface Options {
+            symbol?: string,
+            separator?: string,
+            decimal?: string,
+            errorOnInvalid?: boolean,
+            precision?: number,
+            increment?: number,
+            useVedic?: boolean,
+            pattern?: string,
+            negativePattern?: string,
+            format?: currency.Format,
+            fromCents?: boolean
+        }
+    }
+
+    interface currency {
+        add(number: currency.Any): currency;
+        subtract(number: currency.Any): currency;
+        multiply(number: currency.Any): currency;
+        divide(number: currency.Any): currency;
+        distribute(count: number): Array<currency>;
+        dollars(): number;
+        cents(): number;
+        format(opts?: currency.Options | currency.Format): string;
+        toString(): string;
+        toJSON(): number;
+        readonly intValue: number;
+        readonly value: number;
+    }
+
+    const currency: currency.Constructor;
+
+    export = currency;
 }

--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -1,42 +1,42 @@
 declare module 'currency.js' {
-    namespace currency {
-        type Any = number | string | currency;
-        type Format = (currency?: currency, opts?: Options) => string;
-        interface Constructor {
-            (value: currency.Any, opts?: currency.Options): currency,
-            new(value: currency.Any, opts?: currency.Options): currency
-        }
-        interface Options {
-            symbol?: string,
-            separator?: string,
-            decimal?: string,
-            errorOnInvalid?: boolean,
-            precision?: number,
-            increment?: number,
-            useVedic?: boolean,
-            pattern?: string,
-            negativePattern?: string,
-            format?: currency.Format,
-            fromCents?: boolean
-        }
+  namespace currency {
+    type Any = number | string | currency;
+    type Format = (currency?: currency, opts?: Options) => string;
+    interface Constructor {
+      (value: currency.Any, opts?: currency.Options): currency,
+      new(value: currency.Any, opts?: currency.Options): currency
     }
-
-    interface currency {
-        add(number: currency.Any): currency;
-        subtract(number: currency.Any): currency;
-        multiply(number: currency.Any): currency;
-        divide(number: currency.Any): currency;
-        distribute(count: number): Array<currency>;
-        dollars(): number;
-        cents(): number;
-        format(opts?: currency.Options | currency.Format): string;
-        toString(): string;
-        toJSON(): number;
-        readonly intValue: number;
-        readonly value: number;
+    interface Options {
+      symbol?: string,
+      separator?: string,
+      decimal?: string,
+      errorOnInvalid?: boolean,
+      precision?: number,
+      increment?: number,
+      useVedic?: boolean,
+      pattern?: string,
+      negativePattern?: string,
+      format?: currency.Format,
+      fromCents?: boolean
     }
+  }
 
-    const currency: currency.Constructor;
+  interface currency {
+    add(number: currency.Any): currency;
+    subtract(number: currency.Any): currency;
+    multiply(number: currency.Any): currency;
+    divide(number: currency.Any): currency;
+    distribute(count: number): Array<currency>;
+    dollars(): number;
+    cents(): number;
+    format(opts?: currency.Options | currency.Format): string;
+    toString(): string;
+    toJSON(): number;
+    readonly intValue: number;
+    readonly value: number;
+  }
 
-    export = currency;
+  const currency: currency.Constructor;
+
+  export = currency;
 }


### PR DESCRIPTION
ISSUE: The currency export is also declared globally as a namespace const and constructor.

When importing currency.js once in a module, TypeScript loads this declaration file and declares `currency` global and assumes it's available in all modules. This is not true and will give runtime errors. Exporting`currency` inside the module declaration ensures it's is imported in every module that is using it because TS will give compile errors.