### PR TITLE
#293 Format precision

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,7 @@
 {
-  "extends": ["@scurker"],
+  "extends": [
+    "@scurker"
+  ],
   "env": {
     "node": true,
     "browser": true,
@@ -7,6 +9,6 @@
   },
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 8
+    "ecmaVersion": 2020
   }
 }

--- a/docs/04-api.md
+++ b/docs/04-api.md
@@ -95,7 +95,7 @@ currency("1,234,567/90").add("200,000").format(); // => "$1,434,567.89"
 The default formatter can be overridden by passing in options as a second parameter.
 
 ```js
-var euro = value => currency(value, { separator: ' ', decimal: ',', format: ... });
+var euro = value => currency(value, { separator: ' ', decimal: ',', precision: 0, format: ... });
 
 // ...
 

--- a/test/test.js
+++ b/test/test.js
@@ -394,6 +394,16 @@ test('should override defaults options when formatting with options', t => {
   t.is(currency(1.23, { symbol: '$' }).format({ symbol: '£' }), '£1.23', 'value is not "£1.23"');
 });
 
+test('should allow for precision to be passed in to format and override', t => {
+  let c1 = currency('1,234.00', { precision: 2 });
+  let c2 = currency('1,234.5678');
+  let c3 = currency('1,234,567.8900');
+
+  t.is(c1.format({ precision: 0 }), '$1,234');
+  t.is(c2.format({ precision: 3 }), '$1,234.570');
+  t.is(c3.format({ precision: 4 }), '$1,234,567.8900');
+});
+
 test('should return 0.00 currency with invalid input', t => {
   // eslint-disable-next-line no-undefined
   var value = currency(undefined);


### PR DESCRIPTION
This PR might need some heavy critiquing. It works by creating a new instance of currency if a precision option is passed into the format function. This will overwrite the precision value from the instantiation, however. Feel free to outright reject it and maybe suggest a better way to do it and I'd be happy to do that instead. It works though. New tests are written and all the old ones pass.

#293 