### PR TITLE
#132 division by another currency object returns number

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -138,12 +138,17 @@ currency.prototype = {
 
   /**
    * Divides value.
-   * @param {number} number
+   * @param {number|currency} value
    * @returns {currency}
    */
-  divide(number) {
+  divide(value) {
     let { intValue, _settings } = this;
-    return currency(intValue /= parse(number, _settings, false), _settings);
+
+    if (value instanceof currency) {
+      return intValue / parse(value, _settings, false);
+    }
+    
+    return currency(intValue /= parse(value, _settings, false), _settings);
   },
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -556,3 +556,7 @@ test('should handle fractional cents', t => {
   t.is(values.intValue, 1235);
   t.is(values.value, 12.35);
 });
+
+test('division by currency should result in a number, not currency', t => {
+  t.is(currency(110).divide(currency(20)), 5.5);
+});


### PR DESCRIPTION
When dividing one currency by another, it will now return a number. Test added. Didn't add anything to the docs though...

#132 