### PR TITLE
Remove outdated libs from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,9 +170,7 @@ GAS(1234.56).format(); // "$1,234.560"
 
 Maybe currency.js isn't the right fit for your needs. Check out some of these other fine libraries:
 
-* [accounting.js](https://github.com/openexchangerates/accounting.js)
 * [dinero.js](https://github.com/sarahdayan/dinero.js)
-* [walletjs](https://github.com/dleitee/walletjs)
 
 ## License
 


### PR DESCRIPTION
walletsjs and accounting.js have not received any commits since 2017, so I think it would be better to remove the references to them.