### PR TITLE
docs(readme): add currency-to-float alternative

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ Maybe currency.js isn't the right fit for your needs. Check out some of these ot
 * [accounting.js](https://github.com/openexchangerates/accounting.js)
 * [dinero.js](https://github.com/sarahdayan/dinero.js)
 * [walletjs](https://github.com/dleitee/walletjs)
+* [currency-to-float](https://github.com/mateus4k/currency-to-float)
 
 ## License
 


### PR DESCRIPTION
[currency-to-float](https://www.npmjs.com/package/currency-to-float) is an alternative for **transforming formatted currency strings into their numeric value**. It has excellent performance, no additional dependencies and at least 15 currencies supported!