### PR TITLE
fix: allow null and undefined in currency.Any type

### DIFF
--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -1,6 +1,6 @@
 declare module 'currency.js' {
   namespace currency {
-    type Any = number | string | currency;
+    type Any = number | string | currency | null | undefined;
     type Format = (currency?: currency, opts?: Options) => string;
     interface Constructor {
       (value: currency.Any, opts?: currency.Options): currency,


### PR DESCRIPTION
## Description

The TypeScript definition for `currency.Any` only included `number | string | currency`, but the runtime accepts `null` and `undefined` (defaulting them to 0). This mismatch causes TypeScript errors when passing nullable values from API responses or form fields.

## Changes

- `src/currency.d.ts`: Added `undefined | null` to the `currency.Any` type union

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #446