### PR TITLE
docs: add usage examples for properties, negatives, comparisons, and TypeScript

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,27 @@ Formats number groupings using the Indian Numbering System, i.e. `10,00,000.00`
 `fromCents` *default*: `false`<br/>
 Parse the amount value as a minor currency unit (e.g. cents in a dollar) instead of dollars.
 
+### Additional Examples
+
+```javascript
+// Properties
+currency(123.45).value;        // 123.45
+currency(123.45).intValue;     // 12345
+
+// Negative values
+currency(-5.50);               // -5.50
+currency("(5.50)");            // -5.50
+currency("-5.50");             // -5.50
+
+// Comparisons
+currency(1.23).equals(1.23);         // true
+currency(1.23).greaterThan(1.00);    // true
+currency(1.23).lessThan(2.00);       // true
+
+// TypeScript (types included in the package)
+import currency from 'currency.js';
+```
+
 > View more examples and full documentation at [https://currency.js.org](https://currency.js.org).
 
 ### Internationalization Examples


### PR DESCRIPTION
## Description

Adds additional usage examples to the README as requested: `value` and `intValue` properties, constructing with negative numbers (`-5.50` and `(5.50)`), comparison methods (`equals`, `greaterThan`, `lessThan`), and TypeScript import syntax.

## Changes

- `readme.md`: Added an "Additional Examples" section before the existing documentation link.

## Type of Change
- [x] Documentation

## Related Issue
Fixes #440