### PR TITLE
fix: add groups option to TypeScript Options interface

### DIFF
--- a/src/currency.d.ts
+++ b/src/currency.d.ts
@@ -17,7 +17,8 @@ declare module 'currency.js' {
       pattern?: string,
       negativePattern?: string,
       format?: currency.Format,
-      fromCents?: boolean
+      fromCents?: boolean,
+      groups?: RegExp
     }
   }
 


### PR DESCRIPTION
## Description

The `groups` option was missing from the TypeScript `Options` interface, causing type errors when users passed a custom grouping regex. The runtime already supports this option (used in formatting logic for digit grouping).

## Changes

- `src/currency.d.ts`: Added `groups?: RegExp` to the `Options` interface

## Type of Change
- [x] Bug fix

## Related Issue
Fixes #450