### PR TITLE
fix: stop distribute() from looping forever on a non-positive count

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -159,7 +159,7 @@ currency.prototype = {
       , pennies = Math.abs(intValue - (split * count))
       , precision =  _settings.fromCents ? 1 : _precision;
 
-    for (; count !== 0; count--) {
+    for (let i = 0; i < count; i++) {
       let item = currency(split / precision, _settings);
 
       // Add any left over pennies

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,11 @@ test('should create equal distribution', t => {
   t.deepEqual(realValues, [0.25, 0.25, 0.25, 0.25], 'all distributed items are equal');
 });
 
+test('should not loop forever for a non-positive count', t => {
+  t.deepEqual(currency(1.00).distribute(0), [], 'distribute(0) is empty');
+  t.deepEqual(currency(1.00).distribute(-1), [], 'distribute(-1) is empty instead of looping forever');
+});
+
 test('should create non-equal distribution with pennies', t => {
   var values = currency(1.01).distribute(4);
 


### PR DESCRIPTION
### Problem

`distribute(count)` loops with `for (; count !== 0; count--)`, which only reaches `0` for a positive integer `count`. A **negative** or **fractional** count decrements past `0` forever, pushing `currency` objects into the result array until the process runs out of memory:

```js
const currency = require('currency.js');

currency(1).distribute(-1);   // never returns -> FATAL ERROR: heap out of memory
currency(1).distribute(2.5);  // never returns -> FATAL ERROR: heap out of memory
```

`count` is part of the public, `number`-typed API (`distribute(count: number)`), so a caller-supplied (e.g. user-controlled) value can hang and crash the process. `distribute(0)` already returns `[]`, so the positive-integer assumption is only implicit.

### Fix

Bound the loop with `for (let i = 0; i < count; i++)` so it always terminates. A non-positive count now yields an empty distribution (consistent with `distribute(0)`), and positive-integer counts behave exactly as before (the loop body never referenced `count`).

### Test

Added a test asserting `distribute(0)` and `distribute(-1)` return `[]` instead of looping forever. The full suite passes (63 tests).