### PR TITLE
fix: do not retain fromCents on derived instances (#425)

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -33,6 +33,13 @@ function currency(value, opts) {
     , precision = pow(settings.precision)
     , v = parse(value, settings);
 
+  // `fromCents` governs only how the *initial* value is parsed. It must not be
+  // retained on the instance: derived instances (add/subtract/multiply/divide)
+  // pass their already-scaled integer value back through the constructor, and a
+  // lingering `fromCents` would make it re-interpret that value as cents and
+  // mis-scale on every subsequent operation. See #425.
+  settings.fromCents = false;
+
   that.intValue = v;
   that.value = v / precision;
 

--- a/test/test.js
+++ b/test/test.js
@@ -520,6 +520,25 @@ test('should parse cents from a string when using fromCents option', t => {
   t.is(c3.intValue, 123);
 });
 
+test('should not carry the fromCents option into derived instances', t => {
+  // `fromCents` only affects how the initial value is parsed; derived instances
+  // (divide/multiply/add/...) must behave identically to a plain instance. See #425.
+  let fromCents = currency('800000', { fromCents: true, precision: 4 });
+  let plain = currency('80.00', { precision: 4 });
+  let divisor = currency('80.00', { precision: 4 });
+  let discount = currency('20.00', { precision: 4 });
+
+  t.is(
+    discount.multiply(fromCents.divide(divisor)).value,
+    discount.multiply(plain.divide(divisor)).value,
+    'a fromCents-derived chain should match the plain-derived chain'
+  );
+  t.is(discount.multiply(fromCents.divide(divisor)).value, 20);
+
+  // Arithmetic operates in the main unit, not cents, once parsed.
+  t.is(currency(500, { fromCents: true }).add(5).value, 10);
+});
+
 test('should handle add with fromCents option', t => {
   let c1 = currency(12345, { fromCents: true });
   let c2 = currency(123, { fromCents: true });


### PR DESCRIPTION
Fixes #425

## What was wrong

`fromCents` is only meant to control how the **initial** value is parsed (interpret it as integer cents). But the flag was stored on the instance's `_settings` and carried into every derived instance produced by `add` / `subtract` / `multiply` / `divide`.

Those methods pass their already-scaled integer value back through the constructor. With `fromCents` still set, the constructor skips the `* precision` scaling and re-interprets that integer as cents, so the value is mis-scaled on every subsequent operation:

```js
const sub  = currency('800000', { fromCents: true, precision: 4 }); // 80.0000
const div  = currency('80.00',  { precision: 4 });
const disc = currency('20.00',  { precision: 4 });

disc.multiply(sub.divide(div)).value; // => 0.002  (should be 20)
```

## Fix

Reset `fromCents` to `false` immediately after the initial parse, so the flag governs only that first parse and derived instances behave like any other `currency`. One line in the constructor.

## Test

Adds a regression test covering the reporter's divide/multiply chain (now matches the equivalent plain-instance chain and returns `20`) and an `add` case. Verified the new test fails on `main` (returns `0.002`) and passes with this change.

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening.*