### PR TITLE
fix: return correct dollars() for values beyond the 32-bit integer range

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -176,7 +176,7 @@ currency.prototype = {
    * @returns {number}
    */
   dollars() {
-    return ~~this.value;
+    return Math[this.value >= 0 ? 'floor' : 'ceil'](this.value) || 0;
   },
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -199,6 +199,18 @@ test('should get dollar value', t => {
   t.is(value.subtract(3).dollars(), -1, 'is negative dollar amount');
 });
 
+test('should get dollar values outside the signed 32-bit range', t => {
+  [2147483648.99, 4294967296.99, 90071992547.12].forEach(value => {
+    t.is(currency(value).dollars(), Math.floor(value));
+    t.is(currency(-value).dollars(), -Math.floor(value));
+  });
+});
+
+test('should preserve zero for dollar values below one', t => {
+  t.is(currency(.99).dollars(), 0);
+  t.is(currency(-.99).dollars(), 0);
+});
+
 test('should get cent value', t => {
   var value = currency(1.23);
 


### PR DESCRIPTION
## Problem

`dollars()` truncates with `~~this.value`, which coerces to a signed 32-bit integer. Any amount above 2,147,483,647 wraps around:

```js
currency('90071992547').dollars(); // -122320669, expected 90071992547
currency(2147483648.99).dollars(); // -2147483648
```

The README says values up to 2^53 cents (90,071,992,547,409.91) are supported, so this is inside the advertised range. Reported in #226 (closed as a Number limit, but as a later comment there noted, `Math.floor` gives the right answer for the same input).

## Fix

Truncate toward zero with `Math.floor` / `Math.ceil` instead of `~~`. Behaviour for the existing tests is unchanged, including `currency(-.99).dollars() === 0` (the `|| 0` guard avoids returning `-0`).

## Tests

- Added a test for values above 2^31 and 2^32 (positive and negative).
- Added a test that fractional values below one dollar still yield `0`.
- `npm test` (64 tests) and `npm run lint` pass on Node 16.

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtpcFAThUxrGAyCyxiiEC5
